### PR TITLE
Remove unused params

### DIFF
--- a/test/tests/optimizationreporter/objective_minimize/mechanics/forward.i
+++ b/test/tests/optimizationreporter/objective_minimize/mechanics/forward.i
@@ -92,7 +92,6 @@
     poissons_ratio = 0.3
   []
   [stress]
-    displacements ='disp_x disp_y'
     type = ComputeLinearElasticStress
   []
 []


### PR DESCRIPTION
MOOSE is changing the default behavior of unused parameters from a warning to an error. Since there are tests in this Moose app with unused parameters, this app's tests must have there unused parameters removed.

Closes #28 