### PR TITLE
skipping valgrind on long test

### DIFF
--- a/test/tests/optimizationreporter/objective_gradient_minimize/nonlinear/tests
+++ b/test/tests/optimizationreporter/objective_gradient_minimize/nonlinear/tests
@@ -11,6 +11,7 @@
     csvdiff     = main_out_OptimizationReporter_0001.csv
     cli_args    = "Executioner/tao_solver=taolmvm"
     max_threads = 1
+    valgrind = none
     # steady solve
     recover = false
   []


### PR DESCRIPTION
 Previous commit that changed solver options didn't speed up the valgrind test enough so I am skipping valgrind for this the bfgs solver.  All of the code is still covered and tested in the Newton test.  closes #44