### PR TITLE
Changed JSONDiff in tests to upcoming SchemaDiff

### DIFF
--- a/examples/simpleTransient/tests
+++ b/examples/simpleTransient/tests
@@ -15,10 +15,10 @@
       detail = 'only forward solve;'
     []
     [gradient]
-      type = JSONDiff
+      type = SchemaDiff
       input = main_gradient.i
       cli_args = 'Outputs/out/execute_system_information_on=none'
-      jsondiff = main_gradient_out.json
+      schemadiff = main_gradient_out.json
       rel_err = 1e-4
       heavy = true
       method = OPT

--- a/test/tests/optimizationreporter/base/tests
+++ b/test/tests/optimizationreporter/base/tests
@@ -3,16 +3,16 @@
   design = 'OptimizationReporter/index.md'
   requirement = "The system shall correctly read in "
   [input]
-    type = JSONDiff
+    type = SchemaDiff
     input = optRep_fromInput.i
-    jsondiff = optRep_fromInput_out.json
+    schemadiff = optRep_fromInput_out.json
     allow_test_objects = true
     detail = "parameter data from the input file and and measurment data from the input file."
   []
   [csv]
-    type = JSONDiff
+    type = SchemaNDiff
     input = optRep_fromCsv.i
-    jsondiff = optRep_fromCsv_out.json
+    schemadiff = optRep_fromCsv_out.json
     allow_test_objects = true
     detail = "parameter data from the input file and and measurment data from a CSV file."
    []

--- a/test/tests/reporter/GriddedDataReporter/tests
+++ b/test/tests/reporter/GriddedDataReporter/tests
@@ -1,8 +1,8 @@
 [Tests]
   [xyGrid]
     requirement = "This tests that a reporter is able to read in a gridded data file and produce the appropriate grid from it that can be used in PiecewiseMultiInterpolation like functions."
-    type = JSONDiff
+    type = SchemaDiff
     input = 'griddedData.i'
-    jsondiff= 'griddedData_out.json'
+    schemadiff= 'griddedData_out.json'
   []
 []


### PR DESCRIPTION
The old JSON and XML differs are being changed to a universal schema differ with more functionality. That means that isopod will fail its tests until their tests are changed. This shouldn't be merged in immediately, coordinating these changes will be important.

Closes idaholab/moose#22219 

SchemaDiff PR: https://github.com/idaholab/moose/pull/21791