### PR TITLE
Batch material gradient for elastic property inversion

### DIFF
--- a/examples/bimaterialElastic_batch_mat/gold/main_out_OptimizationReporter_0001.csv
+++ b/examples/bimaterialElastic_batch_mat/gold/main_out_OptimizationReporter_0001.csv
@@ -1,0 +1,1 @@
+../../bimaterialElastic/gold/main_out_OptimizationReporter_0001.csv

--- a/examples/bimaterialElastic_batch_mat/grad.i
+++ b/examples/bimaterialElastic_batch_mat/grad.i
@@ -1,0 +1,204 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 11
+    ny = 11
+    xmin = -4
+    xmax = 4
+    ymin = -4
+    ymax = 4
+  []
+[]
+
+[Variables]
+  [ux]
+  []
+  [uy]
+  []
+[]
+
+[AuxVariables]
+  [state_x]
+  []
+  [state_y]
+  []
+  [dummy]
+  []
+[]
+
+[DiracKernels]
+  [misfit_is_adjoint_force]
+    type = ReporterPointSource
+    variable = ux
+    x_coord_name = misfit/measurement_xcoord
+    y_coord_name = misfit/measurement_ycoord
+    z_coord_name = misfit/measurement_zcoord
+    value_name = misfit/misfit_values
+  []
+[]
+
+[Kernels]
+  [div_sigma_x]
+    type = StressDivergenceTensors
+    variable = ux
+    displacements = 'ux uy'
+    component = 0
+    volumetric_locking_correction = false
+  []
+  [div_sigma_y]
+    type = StressDivergenceTensors
+    variable = uy
+    displacements = 'ux uy'
+    component = 1
+    volumetric_locking_correction = false
+  []
+[]
+
+[BCs]
+  [bottom_ux]
+    type = DirichletBC
+    variable = ux
+    boundary = bottom
+    value = 0.0
+  []
+  [bottom_uy]
+    type = DirichletBC
+    variable = uy
+    boundary = bottom
+    value = 0.0
+  []
+[]
+
+[Materials]
+  [stress]
+    type = ComputeLinearElasticStress
+  []
+  [strain]
+    type = ComputeSmallStrain
+    displacements = 'ux uy'
+  []
+  [elasticity_tensor]
+    type = ComputeVariableIsotropicElasticityTensor
+    args = dummy
+    youngs_modulus = E_material
+    poissons_ratio = nu_material
+  []
+  [E_material]
+    type = GenericFunctionMaterial
+    prop_names = 'E_material'
+    prop_values = E
+  []
+  [nu_material]
+    type = GenericFunctionMaterial
+    prop_names = 'nu_material'
+    prop_values = nu
+  []
+  [forward_strain]
+    type = ComputeSmallStrain
+    displacements = 'state_x state_y'
+    base_name = 'forward'
+  []
+  # Below are the gradients of elasticity tensor for this elastic inversion problem
+  [dC_dlambda]
+    type = ComputeElasticityTensor
+    C_ijkl = '1 1 1 1 1 1 0 0 0'
+    fill_method = symmetric9
+    base_name = 'dC_dlambda'
+  []
+  [dC_dmu]
+    type = ComputeElasticityTensor
+    C_ijkl = '2 0 0 2 0 2 1 1 1'
+    fill_method = symmetric9
+    base_name = 'dC_dmu'
+  []
+[]
+
+[Functions]
+  [E]
+    type = ParsedFunction
+    expression = mu*(3*lambda+2*mu)/(lambda+mu)
+    symbol_names = 'lambda mu'
+    symbol_values = 'lambda mu'
+  []
+  [nu]
+    type = ParsedFunction
+    expression = lambda/2/(lambda+mu)
+    symbol_names = 'lambda mu'
+    symbol_values = 'lambda mu'
+  []
+  [lambda]
+    type = NearestReporterCoordinatesFunction
+    x_coord_name = parametrization/coordx
+    y_coord_name = parametrization/coordy
+    value_name = parametrization/lambda
+  []
+  [mu]
+    type = NearestReporterCoordinatesFunction
+    x_coord_name = parametrization/coordx
+    y_coord_name = parametrization/coordy
+    value_name = parametrization/mu
+  []
+[]
+
+[Reporters]
+  [measure_data]
+    type = OptimizationData
+    variable = ux
+  []
+  [misfit]
+    type = OptimizationData
+  []
+  [parametrization]
+    type = ConstantReporter
+    real_vector_names = 'coordx coordy lambda mu'
+    real_vector_values = '0 1 2; 0 1 2; 5 4 3; 1 2 3'
+  []
+[]
+
+# Below is the part where a customized userObject that takes NEML stress gradient
+# and transforms it into a batch material that has the output type as RankTwoTensor
+# One userObject per gradient material property from NEML
+[UserObjects]
+  [stress_grad_lambda]
+    type = BatchStressGrad
+    elastic_tensor_derivative = 'dC_dlambda_elasticity_tensor' # calculated in dC_dlambda
+    execute_on = NONLINEAR # need to make sure that the UO runs before the VPP
+  []
+  [stress_grad_mu]
+    type = BatchStressGrad
+    elastic_tensor_derivative = 'dC_dmu_elasticity_tensor' # calculated in dC_dmu
+    execute_on = NONLINEAR # need to make sure that the UO runs before the VPP
+  []
+[]
+
+# Below is where the stress gradient batch material objects are utilized in the
+# actual gradient calculations
+[VectorPostprocessors]
+  [grad_lambda]
+    type = ElementOptimizationAdjointStrainStressGradInnerProduct
+    stress_grad_name = 'stress_grad_lambda'
+    # not used
+    variable = dummy
+    function = lambda
+  []
+  [grad_mu]
+    type = ElementOptimizationAdjointStrainStressGradInnerProduct
+    stress_grad_name = 'stress_grad_mu'
+    # not used
+    variable = dummy
+    function = mu
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+[]
+
+[Outputs]
+  file_base = 'adjoint'
+  console = false
+[]

--- a/examples/bimaterialElastic_batch_mat/main.i
+++ b/examples/bimaterialElastic_batch_mat/main.i
@@ -1,0 +1,126 @@
+[Optimization]
+[]
+
+[OptimizationReporter]
+  type = OptimizationReporter
+  parameter_names = 'lambda mu'
+  num_values = '3 3'
+  #initial_condition = '5 4 3 ; 1 2 1'
+  initial_condition = '5.0 5.0 5.0; 1.0 1.0 1.0'
+  lower_bounds = '0.1; 0.1'
+  upper_bounds = '10.0; 10.0'
+  measurement_points = '-1.0 -1.0 0.0
+                        -1.0  0.0 0.0
+                        -1.0  1.0 0.0
+                         0.0 -1.0 0.0
+                         0.0  0.0 0.0
+                         0.0  1.0 0.0
+                         1.0 -1.0 0.0
+                         1.0  0.0 0.0
+                         1.0  1.0 0.0'
+  measurement_values = '4.464620e+00 6.447155e+00 8.434803e+00
+                        4.176264e+00 6.172984e+00 8.200859e+00
+                        4.049477e+00 6.052499e+00 8.079385e+00'
+[]
+
+[Executioner]
+  type = Optimize
+  tao_solver = taobqnls #taobncg #taoblmvm
+  petsc_options_iname = '-tao_gatol -tao_ls_type -tao_max_it'
+  petsc_options_value = '5e-6 unit 500'
+
+  #THESE OPTIONS ARE FOR TESTING THE ADJOINT GRADIENT
+  #petsc_options_iname='-tao_max_it -tao_fd_test -tao_test_gradient -tao_fd_gradient -tao_fd_delta -tao_gatol'
+  #petsc_options_value='1 true true false 1e-8 0.1'
+  #petsc_options = '-tao_test_gradient_view'
+  verbose = true
+[]
+
+[MultiApps]
+  [forward]
+    type = FullSolveMultiApp
+    input_files = model.i
+    execute_on = FORWARD
+  []
+  [adjoint]
+    type = FullSolveMultiApp
+    input_files = grad.i
+    execute_on = ADJOINT
+  []
+[]
+
+[Transfers]
+  [toForward]
+    type = MultiAppReporterTransfer
+    to_multi_app = forward
+    from_reporters = 'OptimizationReporter/measurement_xcoord
+                      OptimizationReporter/measurement_ycoord
+                      OptimizationReporter/measurement_zcoord
+                      OptimizationReporter/measurement_time
+                      OptimizationReporter/measurement_values
+                      OptimizationReporter/lambda
+                      OptimizationReporter/mu'
+    to_reporters = 'measure_data/measurement_xcoord
+                    measure_data/measurement_ycoord
+                    measure_data/measurement_zcoord
+                    measure_data/measurement_time
+                    measure_data/measurement_values
+                    parametrization/lambda
+                    parametrization/mu'
+  []
+  [get_misfit]
+    type = MultiAppReporterTransfer
+    from_multi_app = forward
+    from_reporters = 'measure_data/simulation_values'
+    to_reporters = 'OptimizationReporter/simulation_values'
+  []
+  [set_state_for_adjoint]
+    type = MultiAppCopyTransfer
+    from_multi_app = forward
+    to_multi_app = adjoint
+    source_variable = 'ux uy'
+    variable = 'state_x state_y'
+  []
+  [setup_adjoint_run]
+    type = MultiAppReporterTransfer
+    to_multi_app = adjoint
+    from_reporters = 'OptimizationReporter/measurement_xcoord
+                      OptimizationReporter/measurement_ycoord
+                      OptimizationReporter/measurement_zcoord
+                      OptimizationReporter/measurement_time
+                      OptimizationReporter/misfit_values
+                      OptimizationReporter/lambda
+                      OptimizationReporter/mu'
+    to_reporters = 'misfit/measurement_xcoord
+                    misfit/measurement_ycoord
+                    misfit/measurement_zcoord
+                    misfit/measurement_time
+                    misfit/misfit_values
+                    parametrization/lambda
+                    parametrization/mu'
+  []
+  [get_grad_lambda]
+    type = MultiAppReporterTransfer
+    from_multi_app = adjoint
+    from_reporters = 'grad_lambda/inner_product'
+    to_reporters = 'OptimizationReporter/grad_lambda'
+  []
+  [get_grad_mu]
+    type = MultiAppReporterTransfer
+    from_multi_app = adjoint
+    from_reporters = 'grad_mu/inner_product'
+    to_reporters = 'OptimizationReporter/grad_mu'
+  []
+[]
+
+[Reporters]
+  [optInfo]
+    type = OptimizationInfo
+    items = 'current_iterate function_value gnorm'
+  []
+[]
+
+[Outputs]
+  console = false
+  csv = true
+[]

--- a/examples/bimaterialElastic_batch_mat/model.i
+++ b/examples/bimaterialElastic_batch_mat/model.i
@@ -1,0 +1,166 @@
+[Mesh]
+  [gmg]
+    type = GeneratedMeshGenerator
+    dim = 2
+    nx = 11
+    ny = 11
+    xmin = -4
+    xmax = 4
+    ymin = -4
+    ymax = 4
+  []
+[]
+
+[Variables]
+  [ux]
+  []
+  [uy]
+  []
+[]
+
+[AuxVariables]
+  [dummy]
+  []
+[]
+
+[Kernels]
+  [div_sigma_x]
+    type = StressDivergenceTensors
+    variable = ux
+    displacements = 'ux uy'
+    component = 0
+    volumetric_locking_correction = false
+  []
+  [div_sigma_y]
+    type = StressDivergenceTensors
+    variable = uy
+    displacements = 'ux uy'
+    component = 1
+    volumetric_locking_correction = false
+  []
+[]
+
+[BCs]
+  [bottom_ux]
+    type = DirichletBC
+    variable = ux
+    boundary = bottom
+    value = 0.0
+  []
+  [bottom_uy]
+    type = DirichletBC
+    variable = uy
+    boundary = bottom
+    value = 0.0
+  []
+  [top_fx]
+    type = NeumannBC
+    variable = ux
+    boundary = top
+    value = 1.0
+  []
+  [top_fy]
+    type = NeumannBC
+    variable = uy
+    boundary = top
+    value = 1.0
+  []
+[]
+
+[Materials]
+  [stress]
+    type = ComputeLinearElasticStress
+  []
+  [strain]
+    type = ComputeSmallStrain
+    displacements = 'ux uy'
+  []
+  [elasticity_tensor]
+     type = ComputeVariableIsotropicElasticityTensor
+     args = dummy
+     youngs_modulus = E_material
+     poissons_ratio = nu_material
+  []
+  [E_material]
+    type = GenericFunctionMaterial
+    prop_names = 'E_material'
+    prop_values = E
+  []
+  [nu_material]
+    type = GenericFunctionMaterial
+    prop_names = 'nu_material'
+    prop_values = nu
+  []
+[]
+
+[Functions]
+  [E]
+    type = ParsedFunction
+    expression = mu*(3*lambda+2*mu)/(lambda+mu)
+    symbol_names = 'lambda mu'
+    symbol_values = 'lambda mu'
+  []
+  [nu]
+    type = ParsedFunction
+    expression = lambda/2/(lambda+mu)
+    symbol_names = 'lambda mu'
+    symbol_values = 'lambda mu'
+  []
+  [lambda]
+    type = NearestReporterCoordinatesFunction
+    x_coord_name = parametrization/coordx
+    y_coord_name = parametrization/coordy
+    value_name = parametrization/lambda
+  []
+  [mu]
+    type = NearestReporterCoordinatesFunction
+    x_coord_name = parametrization/coordx
+    y_coord_name = parametrization/coordy
+    value_name = parametrization/mu
+  []
+[]
+
+[Reporters]
+  [measure_data]
+    type = OptimizationData
+    variable = ux
+  []
+  [parametrization]
+    type = ConstantReporter
+    real_vector_names = 'coordx coordy lambda mu'
+    real_vector_values = '0 1 2; 0 1 2; 5 4 3; 1 2 3'
+  []
+[]
+
+[Executioner]
+  type = Steady
+  solve_type = NEWTON
+  petsc_options_iname = '-pc_type'
+  petsc_options_value = 'lu'
+[]
+
+[Postprocessors]
+  [point1]
+    type = PointValue
+    point = '-1.0 -1.0 0.0'
+    variable = ux
+    execute_on = TIMESTEP_END
+  []
+  [point2]
+    type = PointValue
+    point = '-1.0 0.0 0.0'
+    variable = ux
+    execute_on = TIMESTEP_END
+  []
+  [point3]
+    type = PointValue
+    point = '-1.0 1.0 0.0'
+    variable = ux
+    execute_on = TIMESTEP_END
+  []
+[]
+
+[Outputs]
+  file_base = 'forward'
+  console = false
+[]

--- a/examples/bimaterialElastic_batch_mat/tests
+++ b/examples/bimaterialElastic_batch_mat/tests
@@ -1,0 +1,15 @@
+[Tests]
+  issues = '#61'
+  [grad]
+    requirement = "The system shall be able to invert for elastic moduli using batch materials."
+    type = CSVDiff
+    abs_zero = 1E-3
+    rel_err = 5e-2
+    input = main.i
+    csvdiff = main_out_OptimizationReporter_0001.csv
+    max_threads = 1
+    method = opt
+    # steady solve
+    recover = false
+  []
+[]

--- a/include/userobjects/BatchStressGrad.h
+++ b/include/userobjects/BatchStressGrad.h
@@ -1,0 +1,33 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "BatchMaterial.h"
+
+typedef BatchMaterial<
+    // tuple representation
+    BatchMaterialUtils::TupleStd,
+    // output data type
+    RankTwoTensor,
+    // gathered input data types:
+    BatchMaterialUtils::GatherMatProp<RankFourTensor>,
+    BatchMaterialUtils::GatherMatProp<RankTwoTensor>>
+
+    BatchStressGradParent;
+
+class BatchStressGrad : public BatchStressGradParent
+{
+public:
+  static InputParameters validParams();
+
+  BatchStressGrad(const InputParameters & params);
+
+  void batchCompute() override;
+};

--- a/include/vectorpostprocessors/ElementOptimizationAdjointStrainStressGradInnerProduct.h
+++ b/include/vectorpostprocessors/ElementOptimizationAdjointStrainStressGradInnerProduct.h
@@ -1,0 +1,31 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#pragma once
+
+#include "ElementOptimizationFunctionInnerProduct.h"
+#include "BatchStressGrad.h"
+
+class ElementOptimizationAdjointStrainStressGradInnerProduct : public ElementOptimizationFunctionInnerProduct
+{
+public:
+  static InputParameters validParams();
+
+  ElementOptimizationAdjointStrainStressGradInnerProduct(const InputParameters & parameters);
+
+protected:
+  virtual Real computeQpInnerProduct() override;
+  /// Base name of the material system
+  const std::string _base_name; // not sure if this is needed
+  /// Holds adjoint strain at current quadrature points
+  const MaterialProperty<RankTwoTensor> & _adjoint_strain;
+  /// UO that holds gradient of stress wrt material parameter at current quadrature points
+  const BatchStressGrad & _stress_grad_uo;
+  const BatchStressGrad::OutputVector & _stress_grad_uo_output;
+};

--- a/src/userobjects/BatchStressGrad.C
+++ b/src/userobjects/BatchStressGrad.C
@@ -1,0 +1,47 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "BatchStressGrad.h"
+#include "libmesh/int_range.h"
+
+registerMooseObject("OptimizationApp", BatchStressGrad);
+
+InputParameters
+BatchStressGrad::validParams()
+{
+  auto params = BatchStressGradParent::validParams();
+  params.addRequiredParam<MaterialPropertyName>(
+      "elastic_tensor_derivative", "Name of the elastic tensor derivative material property.");
+
+  return params;
+}
+
+BatchStressGrad::BatchStressGrad(const InputParameters & params)
+  : BatchStressGradParent(params,
+                          // here we pass the derivative of elastic tensor wrt to the parameter
+                          "elastic_tensor_derivative",
+                          // here we pass in the forward strain
+                          "forward_mechanical_strain")
+{
+}
+
+void
+BatchStressGrad::batchCompute()
+{
+  for (const auto i : index_range(_input_data))
+  {
+    const auto & input = _input_data[i];
+    auto & output = _output_data[i];
+
+    const auto & elasticity_dev = std::get<0>(input);
+    const auto & strain = std::get<1>(input);
+
+    output = elasticity_dev * strain;
+  }
+}

--- a/src/vectorpostprocessors/ElementOptimizationAdjointStrainStressGradInnerProduct.C
+++ b/src/vectorpostprocessors/ElementOptimizationAdjointStrainStressGradInnerProduct.C
@@ -1,0 +1,43 @@
+//* This file is part of the MOOSE framework
+//* https://www.mooseframework.org
+//*
+//* All rights reserved, see COPYRIGHT for full restrictions
+//* https://github.com/idaholab/moose/blob/master/COPYRIGHT
+//*
+//* Licensed under LGPL 2.1, please see LICENSE for details
+//* https://www.gnu.org/licenses/lgpl-2.1.html
+
+#include "ElementOptimizationAdjointStrainStressGradInnerProduct.h"
+
+registerMooseObject("OptimizationApp", ElementOptimizationAdjointStrainStressGradInnerProduct);
+
+InputParameters
+ElementOptimizationAdjointStrainStressGradInnerProduct::validParams()
+{
+  InputParameters params = ElementOptimizationFunctionInnerProduct::validParams();
+  params.addRequiredParam<UserObjectName>(
+      "stress_grad_name",
+      "Name of the stress gradient user object with respect to the material parameter");
+  params.addClassDescription("Compute the gradient for material inversion");
+  return params;
+}
+ElementOptimizationAdjointStrainStressGradInnerProduct::
+    ElementOptimizationAdjointStrainStressGradInnerProduct(const InputParameters & parameters)
+  : ElementOptimizationFunctionInnerProduct(parameters),
+    _base_name(isParamValid("base_name") ? getParam<std::string>("base_name") + "_" : ""),
+    _adjoint_strain(getMaterialPropertyByName<RankTwoTensor>("mechanical_strain")),
+    _stress_grad_uo(getUserObject<BatchStressGrad>("stress_grad_name")),
+    _stress_grad_uo_output(_stress_grad_uo.getOutputData())
+{
+}
+
+Real
+ElementOptimizationAdjointStrainStressGradInnerProduct::computeQpInnerProduct()
+{
+  if (!_stress_grad_uo.outputReady())
+    mooseError("Stress gradient batch material property is not ready to output.");
+
+  const auto index = _stress_grad_uo.getIndex(_current_elem->id());
+
+  return -_adjoint_strain[_qp].doubleContraction(_stress_grad_uo_output[index + _qp]);
+}


### PR DESCRIPTION
Initial implementation of gradient calculation for elastic property inversion using batch material

- Batch material userObject `BatchStressGrad` is implemented for calculating stress gradient wrt parameter
- VectorPostprocessor `ElementOptimizationAdjointStrainStressGradInnerProduct` is implemented to take the stress gradient userObject and calculate the actual gradient value